### PR TITLE
feat: add start script

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+console.log('Arcane Auth Gate server started');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "arcane-auth-gate",
+  "version": "1.0.0",
+  "description": "Arcane Auth Gate is a secure, modular authentication system that enables access to digital products or content *only* for verified Patreon paying members, using Patreon’s API and email matching.   Designed for creators and indie devs who wish to offer truly exclusive “magic-linked” access to supporters.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}


### PR DESCRIPTION
## Summary
- add `start` command to package.json
- create a simple entry point to run with `pnpm start`

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm lint` *(fails: Command "lint" not found)*
- `pnpm typecheck --noEmit` *(fails: Command "typecheck" not found)*
- `pnpm test --runInBand` *(fails: Unknown option)*
- `pnpm start`

------
https://chatgpt.com/codex/tasks/task_e_6842733c0e148331ba54b4eafb33e257